### PR TITLE
bug fix

### DIFF
--- a/dripper/server.py
+++ b/dripper/server.py
@@ -130,7 +130,7 @@ if __name__ == '__main__':
     # The server runs on all network interfaces (0.0.0.0) and uses a single worker
     # process with uvloop for better async performance
     uvicorn.run(
-        'server:app',
+        app,
         host='0.0.0.0',  # Listen on all network interfaces
         port=PORT,
         workers=1,  # Single worker process

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ jieba
 rouge_score
 selectolax
 trafilatura
-vllm==0.10.0
+vllm==0.11.1


### PR DESCRIPTION
1、可行的版本为：transformers==4.57.3,vllm==0.11.1
在requirements.txt里指定了vllm==0.11.1，transformers用户用最新版就不会有问题
2、server.py里用'server:app'会导致ERROR:    Error loading ASGI app. Could not import module "server".
改成直接用app