### PR TITLE
Support passing vLLM kwargs through dripper API

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,12 +177,14 @@ curl http://localhost:7986/health
 | `raise_errors`  | bool | False        | Raise exceptions on errors (vs returning None) |
 | `debug`         | bool | False        | Enable debug logging                           |
 | `early_load`    | bool | False        | Load model during initialization               |
+| `vllm_kwargs`   | dict | `{}`         | Additional kwargs to pass to vLLM constructor  |
 
 ### Environment Variables
 
 - `DRIPPER_MODEL_PATH`: Path to the LLM model
 - `DRIPPER_STATE_MACHINE`: State machine version (default:None)
 - `DRIPPER_PORT`: Server port number (default: 7986)
+- `DRIPPER_VLLM_KWARGS`: JSON string of additional vLLM kwargs (default: `{}`)
 - `VLLM_USE_V1`: Must be set to `'0'` when using state machine
 
 ## Usage Examples

--- a/dripper/api.py
+++ b/dripper/api.py
@@ -69,6 +69,7 @@ class Dripper:
         raise_errors (bool): Whether to raise exceptions on errors
         use_fall_back (bool): Whether to use fallback extraction method
         state_machine (str): State machine version for logits processing
+        vllm_kwargs (Dict[str, Any]): Additional kwargs to pass to vLLM
     """
 
     def __init__(self, config: Dict[str, Any]) -> None:
@@ -90,6 +91,7 @@ class Dripper:
         self.use_fall_back = config.get('use_fall_back', True)
         self.state_machine = config.get('state_machine', None)
         self.early_load = config.get('early_load', False)
+        self.vllm_kwargs = config.get('vllm_kwargs', {})
 
         # Lazy-loaded attributes (initialized on first use)
         self._llm: Optional[LLM] = None
@@ -205,7 +207,9 @@ class Dripper:
             try:
                 logger.info(f'Loading model: {self.model_path}')
                 self._llm = LLM(
-                    model=self.model_path, tensor_parallel_size=self.tp
+                    model=self.model_path, 
+                    tensor_parallel_size=self.tp,
+                    **self.vllm_kwargs
                 )
                 logger.info('Model loading completed')
             except Exception as e:

--- a/dripper/server.py
+++ b/dripper/server.py
@@ -6,6 +6,7 @@ extracted main HTML using the Dripper extraction engine.
 """
 
 import argparse
+import json
 import logging
 import os
 from typing import Any, Dict
@@ -53,6 +54,7 @@ args = parser.parse_args()
 MODEL_PATH = os.getenv('DRIPPER_MODEL_PATH', args.model_path)
 STATE_MACHINE = os.getenv('DRIPPER_STATE_MACHINE', args.state_machine)
 PORT = int(os.getenv('DRIPPER_PORT', str(args.port)))
+VLLM_KWARGS = json.loads(os.getenv('DRIPPER_VLLM_KWARGS', '{}'))
 
 # -------------- Global Singleton --------------
 # Initialize Dripper instance as a global singleton for reuse across requests
@@ -64,6 +66,7 @@ dripper = Dripper(
         'use_fall_back': True,  # Use fallback mechanism on errors
         'raise_errors': False,  # Don't raise exceptions, return None instead
         'early_load': True,  # Load model early during initialization
+        'vllm_kwargs': VLLM_KWARGS,  # Additional vLLM constructor kwargs
     }
 )
 


### PR DESCRIPTION
Support passing vLLM constructor args through dripper to control things like GPU mem utilization, seq len, etc.