### PR TITLE
perf: lazy-load inference backends on import

### DIFF
--- a/mineru_html/__init__.py
+++ b/mineru_html/__init__.py
@@ -1,10 +1,14 @@
 # mineru_html/__init__.py
-from .api import MinerUHTMLConfig, MinerUHTMLGeneric
-from .implementations import (MinerUHTML, MinerUHTML_OpenAI,
-                              MinerUHTML_Transformers)
-from .inference.factory import (create_openai_backend,
-                                create_transformers_backend,
-                                create_vllm_backend)
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .api import MinerUHTMLConfig, MinerUHTMLGeneric
+    from .implementations import (MinerUHTML, MinerUHTML_OpenAI,
+                                  MinerUHTML_Transformers)
+    from .inference.factory import (create_openai_backend,
+                                    create_transformers_backend,
+                                    create_vllm_backend)
 
 __all__ = [
     'MinerUHTMLGeneric',
@@ -16,3 +20,32 @@ __all__ = [
     'create_transformers_backend',
     'create_openai_backend',
 ]
+
+_LAZY_IMPORTS = {
+    'MinerUHTMLGeneric': ('.api', 'MinerUHTMLGeneric'),
+    'MinerUHTMLConfig': ('.api', 'MinerUHTMLConfig'),
+    'MinerUHTML': ('.implementations', 'MinerUHTML'),
+    'MinerUHTML_OpenAI': ('.implementations', 'MinerUHTML_OpenAI'),
+    'MinerUHTML_Transformers': ('.implementations', 'MinerUHTML_Transformers'),
+    'create_vllm_backend': ('.inference.factory', 'create_vllm_backend'),
+    'create_transformers_backend': (
+        '.inference.factory',
+        'create_transformers_backend',
+    ),
+    'create_openai_backend': ('.inference.factory', 'create_openai_backend'),
+}
+
+
+def __getattr__(name: str):
+    if name not in _LAZY_IMPORTS:
+        raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
+    import importlib
+
+    module_name, attr = _LAZY_IMPORTS[name]
+    value = getattr(importlib.import_module(module_name, __name__), attr)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/mineru_html/implementations/__init__.py
+++ b/mineru_html/implementations/__init__.py
@@ -1,5 +1,29 @@
-from .openai_api import MinerUHTML_OpenAI
-from .transformers_api import MinerUHTML_Transformers
-from .vllm_api import MinerUHTML
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .openai_api import MinerUHTML_OpenAI
+    from .transformers_api import MinerUHTML_Transformers
+    from .vllm_api import MinerUHTML
 
 __all__ = ['MinerUHTML', 'MinerUHTML_OpenAI', 'MinerUHTML_Transformers']
+
+_LAZY_IMPORTS = {
+    'MinerUHTML': ('.vllm_api', 'MinerUHTML'),
+    'MinerUHTML_OpenAI': ('.openai_api', 'MinerUHTML_OpenAI'),
+    'MinerUHTML_Transformers': ('.transformers_api', 'MinerUHTML_Transformers'),
+}
+
+
+def __getattr__(name: str):
+    if name not in _LAZY_IMPORTS:
+        raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
+    import importlib
+
+    module_name, attr = _LAZY_IMPORTS[name]
+    value = getattr(importlib.import_module(module_name, __name__), attr)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/mineru_html/implementations/transformers_api.py
+++ b/mineru_html/implementations/transformers_api.py
@@ -1,10 +1,13 @@
-from typing import Any, Dict, Optional
+from __future__ import annotations
 
-from transformers import AutoTokenizer
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from mineru_html.base import DEFALUT_MODEL
 from mineru_html.api import MinerUHTMLConfig, MinerUHTMLGeneric
+from mineru_html.base import DEFALUT_MODEL
 from mineru_html.inference.factory import create_transformers_backend
+
+if TYPE_CHECKING:
+    from transformers import AutoTokenizer
 
 
 class MinerUHTML_Transformers(MinerUHTMLGeneric):

--- a/mineru_html/inference/__init__.py
+++ b/mineru_html/inference/__init__.py
@@ -1,7 +1,11 @@
 # inference/__init__.py
-from .base_backend import InferenceBackend, ModelResponse
-from .factory import (create_openai_backend, create_transformers_backend,
-                      create_vllm_backend)
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .base_backend import InferenceBackend, ModelResponse
+    from .factory import (create_openai_backend, create_transformers_backend,
+                          create_vllm_backend)
 
 __all__ = [
     'InferenceBackend',
@@ -10,3 +14,26 @@ __all__ = [
     'create_transformers_backend',
     'create_openai_backend',
 ]
+
+_LAZY_IMPORTS = {
+    'InferenceBackend': ('.base_backend', 'InferenceBackend'),
+    'ModelResponse': ('.base_backend', 'ModelResponse'),
+    'create_vllm_backend': ('.factory', 'create_vllm_backend'),
+    'create_transformers_backend': ('.factory', 'create_transformers_backend'),
+    'create_openai_backend': ('.factory', 'create_openai_backend'),
+}
+
+
+def __getattr__(name: str):
+    if name not in _LAZY_IMPORTS:
+        raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
+    import importlib
+
+    module_name, attr = _LAZY_IMPORTS[name]
+    value = getattr(importlib.import_module(module_name, __name__), attr)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/mineru_html/inference/base_backend.py
+++ b/mineru_html/inference/base_backend.py
@@ -1,12 +1,15 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple
-
-from transformers import AutoTokenizer
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
 
 from mineru_html.base import MinerUHTMLGenerateInput, MinerUHTMLGenerateOutput
 from mineru_html.exceptions import MinerUHTMLError, MinerUHTMLInputTooLongError
 from mineru_html.utils import build_dummy_response, get_all_item_ids
+
+if TYPE_CHECKING:
+    from transformers import AutoTokenizer
 
 
 @dataclass


### PR DESCRIPTION
Lazy-load inference backends so importing mineru_html no longer eagerly pulls in transformers / torch.

- Use PEP 562 __getattr__ for public exports in mineru_html, implementations, and inference
- Move annotation-only AutoTokenizer imports behind TYPE_CHECKING in base_backend / transformers_api

Install deps and the public API are unchanged. Constructing a Transformers / vLLM / OpenAI backend still loads the usual stack on first use.